### PR TITLE
Fix EVP Encrypt/Decrypt IV handling using EVP_CIPHER_iv_length

### DIFF
--- a/Source/OpenSSL.EncUtils.pas
+++ b/Source/OpenSSL.EncUtils.pas
@@ -127,6 +127,9 @@ var
   Salt :TBytes;
   BuffStart :Integer;
   InputStart :Integer;
+
+  KeyPtr: PAnsiChar;
+  IVPtr: PAnsiChar;
 begin
   if Assigned(FCipherProc) then
     Cipher := FCipherProc()
@@ -177,8 +180,16 @@ begin
     RaiseOpenSSLError('Cannot initialize context');
 
   try
+    KeyPtr := PAnsiChar(@Key[0]);
+    if EVP_CIPHER_iv_length(Cipher) > 0 then begin
+      if Length(InitVector) <> EVP_CIPHER_iv_length(Cipher) then
+        RaiseOpenSSLError('Invalid IV length for cipher');
+      IVPtr := PAnsiChar(@InitVector[0]);
+    end
+    else
+      IVPtr := nil;
 
-    if EVP_DecryptInit_ex(Context, Cipher, nil, @Key[0], @InitVector[0]) <> 1 then
+    if EVP_DecryptInit_ex(Context, Cipher, nil, KeyPtr, IVPtr) <> 1 then
       RaiseOpenSSLError('Cannot initialize decryption process');
 
     SetLength(OutputBuffer, InputStream.Size);
@@ -214,6 +225,9 @@ var
   cipher: PEVP_CIPHER;
   BlockSize :Integer;
   BuffStart :Integer;
+
+  KeyPtr: PAnsiChar;
+  IVPtr: PAnsiChar;
 begin
   BuffStart := 0;
   SetLength(Salt, 0);
@@ -244,7 +258,16 @@ begin
     RaiseOpenSSLError('Cannot initialize context');
 
   try
-    if EVP_EncryptInit_ex(Context, cipher, nil, @Key[0], @InitVector[0]) <> 1 then
+    KeyPtr := PAnsiChar(@Key[0]);
+    if EVP_CIPHER_iv_length(Cipher) > 0 then begin
+      if Length(InitVector) <> EVP_CIPHER_iv_length(Cipher) then
+        RaiseOpenSSLError('Invalid IV length for cipher');
+      IVPtr := PAnsiChar(@InitVector[0]);
+    end
+    else
+      IVPtr := nil;
+
+    if EVP_EncryptInit_ex(Context, cipher, nil, KeyPtr, IVPtr) <> 1 then
       RaiseOpenSSLError('Cannot initialize encryption process');
 
     BlockSize := EVP_CIPHER_CTX_block_size(Context);


### PR DESCRIPTION
## Problem

`TEncUtil.Encrypt` and `TEncUtil.Decrypt` always passed an IV pointer to OpenSSL without checking whether the selected cipher actually uses an IV or what IV size it requires.

This resulted in incorrect behavior for ciphers that do not use an IV (e.g. AES-ECB) and allowed silently passing IVs of invalid length for ciphers that do require an IV.

## Cause

According to the OpenSSL EVP API contract, the `iv` parameter passed to `EVP_EncryptInit_ex` / `EVP_DecryptInit_ex` **must be NULL** when the selected cipher does not use an IV.

The correct way to determine this is `EVP_CIPHER_iv_length(cipher)`.

## Solution

- Determine IV usage based on `EVP_CIPHER_iv_length`
- Pass `nil` IV when `iv_length = 0` (e.g. ECB mode)
- Validate IV length when the cipher requires an IV
- Apply identical logic to both Encrypt and Decrypt paths

## Impact

- Fixes incorrect EVP initialization for ECB mode
- Prevents undefined behavior for invalid IV sizes
- Aligns implementation with OpenSSL EVP API documentation
- No public API changes

## References

- OpenSSL EVP documentation (`EVP_EncryptInit_ex`, `EVP_DecryptInit_ex`)
- `EVP_CIPHER_iv_length` API contract